### PR TITLE
Correct "it's" to "its".

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -369,7 +369,7 @@
    (documented for the first time in 2.3.0).
  - Add Rmpfr_init_set_ld.
  - Add Rmpfr_deref2 to the list of exportable functions, and
-   document it's usage in the POD section.
+   document its usage in the POD section.
  - Rmpfr_deref2 now has the mpfr library allocate (and free) memory
    for the mantissa.
  - Add Rmpfr_hypot (previously missed).

--- a/MPFR.pod
+++ b/MPFR.pod
@@ -236,7 +236,7 @@ Math::MPFR - perl interface to the MPFR (floating point) library.
       Rmpfr_get_float128() or Rmpfr_get_NV()
 
     This will also mean that overloaded operations that receive an
-    NV will evaluate that (__float128) NV to it's full precision.
+    NV will evaluate that (__float128) NV to its full precision.
     And assigning the NV as Math::MPFR->new($nv) will also work as
     intended.
 
@@ -247,7 +247,7 @@ Math::MPFR - perl interface to the MPFR (floating point) library.
       Rmpfr_set_NV() and Rmpfr_get_NV() will still set/get
       __float128 values.
       Also, overloaded operations that receive an NV will still
-      evaluate that (__float128) NV to it's full precision.
+      evaluate that (__float128) NV to its full precision.
       It's only Rmpfr_set_float128() and Rmpfr_get_float128() that
       will not be available.
 


### PR DESCRIPTION
See:

https://www.grammar-monster.com/easily_confused/its_its.htm .

This was broken grammar or spelling .

TODO: do the misspellings also exist in the original libmpfr documentation?