### PR TITLE
Update random2.t

### DIFF
--- a/t/random2.t
+++ b/t/random2.t
@@ -4,29 +4,30 @@
 use Math::MPFR;
 use Test::More;
 
-package Number {
+package Number;
 
-    sub new {
-        my ($class, $n) = @_;
-        bless \$n, $class;
-    }
-
-    sub add {
-        my ($self, $n) = @_;
-        Number->new($$self + $$n);
-    }
-
-    my $srand = 1352406084;
-    my $state = Math::MPFR::Rmpfr_randinit_mt();
-    Math::MPFR::Rmpfr_randseed_ui($state, $srand);
-
-    sub irand2 { # Rmpfr_urandomb
-        my ($self) = @_;
-        my $x = Math::MPFR->new($$self);
-        Math::MPFR::Rmpfr_urandomb($x, $state);
-        return Number->new($x);
-    }
+sub new {
+    my ($class, $n) = @_;
+    bless \$n, $class;
 }
+
+sub add {
+    my ($self, $n) = @_;
+    Number->new($$self + $$n);
+}
+
+my $srand = 1352406084;
+my $state = Math::MPFR::Rmpfr_randinit_mt();
+Math::MPFR::Rmpfr_randseed_ui($state, $srand);
+
+sub irand2 { # Rmpfr_urandomb
+    my ($self) = @_;
+    my $x = Math::MPFR->new($$self);
+    Math::MPFR::Rmpfr_urandomb($x, $state);
+    return Number->new($x);
+}
+
+package main;
 
 my $x = Number->new(420);
 my $second;
@@ -38,6 +39,3 @@ cmp_ok($second, '>=', 420, 'TEST 2: Rmpfr_urandomb ok');
 cmp_ok($second, '<',  421, 'TEST 3: Rmpfr_urandomb ok');
 
 done_testing();
-
-
-


### PR DESCRIPTION
Removed the `package Class {...}` syntax, which is supported only with perl >= 5.14.0.